### PR TITLE
Upgraded jackson JSON libraries to v2.9.8 from v2.8.10 due to security bug in Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,17 +83,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.8.10</version>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.8.10</version>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.8.10</version>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/senzing/api/server/SzApiServer.java
+++ b/src/main/java/com/senzing/api/server/SzApiServer.java
@@ -930,7 +930,7 @@ public class SzApiServer {
     }
 
     this.g2Engine = new G2JNI();
-    this.g2Engine.init(moduleName, ini, verbose);
+    initResult = this.g2Engine.init(moduleName, ini, verbose);
     if (initResult < 0) {
       throw new RuntimeException(buildErrorMessage(
           "Failed to initialize G2Engine API",


### PR DESCRIPTION
Upgrading to version 2.9.8 should address the security issue in Jackson libraries.
