### PR TITLE
Fixed Self Links

### DIFF
--- a/src/main/java/com/senzing/api/model/SzAttributeSearchResponse.java
+++ b/src/main/java/com/senzing/api/model/SzAttributeSearchResponse.java
@@ -1,5 +1,6 @@
 package com.senzing.api.model;
 
+import javax.ws.rs.core.UriInfo;
 import java.util.*;
 
 /**
@@ -35,6 +36,24 @@ public class SzAttributeSearchResponse extends SzResponseWithRawData
                                    String       selfLink)
   {
     super(httpMethod, httpStatusCode, selfLink);
+    this.searchResults = new LinkedList<>();
+  }
+
+  /**
+   * Constructs with only the HTTP method and the {@link UriInfo}, leaving the
+   * license info data to be initialized later.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   *
+   * @param httpStatusCode The HTTP response status code.
+   *
+   * @param uriInfo The {@link UriInfo} associated with the request.
+   */
+  public SzAttributeSearchResponse(SzHttpMethod httpMethod,
+                                   int          httpStatusCode,
+                                   UriInfo      uriInfo)
+  {
+    super(httpMethod, httpStatusCode, uriInfo);
     this.searchResults = new LinkedList<>();
   }
 

--- a/src/main/java/com/senzing/api/model/SzAttributeTypeResponse.java
+++ b/src/main/java/com/senzing/api/model/SzAttributeTypeResponse.java
@@ -1,5 +1,7 @@
 package com.senzing.api.model;
 
+import javax.ws.rs.core.UriInfo;
+
 /**
  * A response object that contains attribute type data.
  *
@@ -44,6 +46,38 @@ public class SzAttributeTypeResponse extends SzResponseWithRawData {
                                  SzAttributeType  data)
   {
     super(httpMethod, httpStatusCode, selfLink);
+    this.attributeType = data;
+  }
+
+  /**
+   * Constructs with only the HTTP method and the {@link UriInfo}, leaving the
+   * attribute type data to be initialized later.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   * @param httpStatusCode The HTTP response code.
+   * @param uriInfo The {@link UriInfo} from the request.
+   */
+  public SzAttributeTypeResponse(SzHttpMethod httpMethod,
+                                 int          httpStatusCode,
+                                 UriInfo      uriInfo) {
+    this(httpMethod, httpStatusCode, uriInfo, null);
+  }
+
+  /**
+   * Constructs with the HTTP method, {@link UriInfo} and the
+   * {@link SzAttributeType} describing the attribute type.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   * @param httpStatusCode The HTTP response status code.
+   * @param uriInfo The {@link UriInfo} from the request.
+   * @param data The {@link SzAttributeType} describing the attribute type.
+   */
+  public SzAttributeTypeResponse(SzHttpMethod     httpMethod,
+                                 int              httpStatusCode,
+                                 UriInfo          uriInfo,
+                                 SzAttributeType  data)
+  {
+    super(httpMethod, httpStatusCode, uriInfo);
     this.attributeType = data;
   }
 

--- a/src/main/java/com/senzing/api/model/SzAttributeTypesResponse.java
+++ b/src/main/java/com/senzing/api/model/SzAttributeTypesResponse.java
@@ -1,5 +1,6 @@
 package com.senzing.api.model;
 
+import javax.ws.rs.core.UriInfo;
 import java.util.*;
 
 /**
@@ -34,6 +35,23 @@ public class SzAttributeTypesResponse extends SzResponseWithRawData
                                   int          httpStatusCode,
                                   String       selfLink) {
     super(httpMethod, httpStatusCode, selfLink);
+    this.attributeTypes = new LinkedList<>();
+  }
+
+  /**
+   * Constructs with only the HTTP method and the {@link UriInfo}, leaving the
+   * data sources to be added later.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   *
+   * @param httpStatusCode The HTTP response status code.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   */
+  public SzAttributeTypesResponse(SzHttpMethod httpMethod,
+                                  int          httpStatusCode,
+                                  UriInfo      uriInfo) {
+    super(httpMethod, httpStatusCode, uriInfo);
     this.attributeTypes = new LinkedList<>();
   }
 

--- a/src/main/java/com/senzing/api/model/SzBasicResponse.java
+++ b/src/main/java/com/senzing/api/model/SzBasicResponse.java
@@ -1,5 +1,7 @@
 package com.senzing.api.model;
 
+import javax.ws.rs.core.UriInfo;
+
 /**
  * The most basic response from the Senzing REST API.  Also servers as a basis
  * for other responses.
@@ -30,6 +32,23 @@ public class SzBasicResponse {
   {
     this.meta = new SzMeta(httpMethod, httpStatusCode);
     this.links = new SzLinks(selfLink);
+  }
+
+  /**
+   * Constructs with the specified HTTP method and {@link UriInfo}.
+   *
+   * @param httpMethod The {@link SzHttpMethod} from the request.
+   *
+   * @param httpStatusCode The HTTP response code.
+   *
+   * @param uriInfo The {@link UriInfo} for the self link.
+   */
+  public SzBasicResponse(SzHttpMethod httpMethod,
+                         int          httpStatusCode,
+                         UriInfo      uriInfo)
+  {
+    this.meta = new SzMeta(httpMethod, httpStatusCode);
+    this.links = new SzLinks(uriInfo);
   }
 
   /**

--- a/src/main/java/com/senzing/api/model/SzDataSourcesResponse.java
+++ b/src/main/java/com/senzing/api/model/SzDataSourcesResponse.java
@@ -1,5 +1,6 @@
 package com.senzing.api.model;
 
+import javax.ws.rs.core.UriInfo;
 import java.util.*;
 
 /**
@@ -33,6 +34,23 @@ public class SzDataSourcesResponse extends SzResponseWithRawData
                                int          httpStatusCode,
                                String       selfLink) {
     super(httpMethod, httpStatusCode, selfLink);
+    this.dataSources = new LinkedHashSet<>();
+  }
+
+  /**
+   * Constructs with only the HTTP method and the {@link UriInfo}, leaving the
+   * data sources to be added later.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   *
+   * @param httpStatusCode The HTTP response status code.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   */
+  public SzDataSourcesResponse(SzHttpMethod httpMethod,
+                               int          httpStatusCode,
+                               UriInfo      uriInfo) {
+    super(httpMethod, httpStatusCode, uriInfo);
     this.dataSources = new LinkedHashSet<>();
   }
 

--- a/src/main/java/com/senzing/api/model/SzEntityNetworkResponse.java
+++ b/src/main/java/com/senzing/api/model/SzEntityNetworkResponse.java
@@ -1,5 +1,7 @@
 package com.senzing.api.model;
 
+import javax.ws.rs.core.UriInfo;
+
 /**
  * A response object that contains entity path data.
  */
@@ -38,6 +40,38 @@ public class SzEntityNetworkResponse extends SzResponseWithRawData {
                                  SzEntityNetworkData  data)
   {
     super(httpMethod, httpStatusCode, selfLink);
+    this.entityNetworkData = data;
+  }
+
+  /**
+   * Constructs with only the HTTP method and the {@link UriInfo}, leaving the
+   * entity data to be initialized later.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   * @param httpStatusCode The HTTP response status code.
+   * @param uriInfo The {@link UriInfo} from the request.
+   */
+  public SzEntityNetworkResponse(SzHttpMethod httpMethod,
+                                 int          httpStatusCode,
+                                 UriInfo      uriInfo) {
+    this(httpMethod, httpStatusCode, uriInfo, null);
+  }
+
+  /**
+   * Constructs with the HTTP method, {@link UriInfo} and the {@link
+   * SzEntityPathData} describing the record.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   * @param httpStatusCode The HTTP response status code.
+   * @param uriInfo The {@link UriInfo} from the request.
+   * @param data The {@link SzEntityRecord} describing the record.
+   */
+  public SzEntityNetworkResponse(SzHttpMethod         httpMethod,
+                                 int                  httpStatusCode,
+                                 UriInfo              uriInfo,
+                                 SzEntityNetworkData  data)
+  {
+    super(httpMethod, httpStatusCode, uriInfo);
     this.entityNetworkData = data;
   }
 

--- a/src/main/java/com/senzing/api/model/SzEntityPathResponse.java
+++ b/src/main/java/com/senzing/api/model/SzEntityPathResponse.java
@@ -1,5 +1,7 @@
 package com.senzing.api.model;
 
+import javax.ws.rs.core.UriInfo;
+
 /**
  * A response object that contains entity path data.
  */
@@ -38,6 +40,38 @@ public class SzEntityPathResponse extends SzResponseWithRawData {
                               SzEntityPathData  data)
   {
     super(httpMethod, httpStatusCode, selfLink);
+    this.entityPathData = data;
+  }
+
+  /**
+   * Constructs with only the HTTP method and the {@link UriInfo}, leaving the
+   * entity data to be initialized later.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   * @param httpStatusCode The HTTP response status code.
+   * @param uriInfo The {@link UriInfo} from the request.
+   */
+  public SzEntityPathResponse(SzHttpMethod httpMethod,
+                              int          httpStatusCode,
+                              UriInfo      uriInfo) {
+    this(httpMethod, httpStatusCode, uriInfo, null);
+  }
+
+  /**
+   * Constructs with the HTTP method, {@link UriInfo} and the {@link
+   * SzEntityPathData} describing the record.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   * @param httpStatusCode The HTTP response status code.
+   * @param uriInfo The {@link UriInfo} from the request.
+   * @param data The {@link SzEntityRecord} describing the record.
+   */
+  public SzEntityPathResponse(SzHttpMethod      httpMethod,
+                              int               httpStatusCode,
+                              UriInfo           uriInfo,
+                              SzEntityPathData  data)
+  {
+    super(httpMethod, httpStatusCode, uriInfo);
     this.entityPathData = data;
   }
 

--- a/src/main/java/com/senzing/api/model/SzEntityResponse.java
+++ b/src/main/java/com/senzing/api/model/SzEntityResponse.java
@@ -1,5 +1,7 @@
 package com.senzing.api.model;
 
+import javax.ws.rs.core.UriInfo;
+
 /**
  * A response object that contains entity data.
  *
@@ -41,6 +43,39 @@ public class SzEntityResponse extends SzResponseWithRawData {
     super(httpMethod, httpStatusCode, selfLink);
     this.entityData = data;
   }
+
+  /**
+   * Constructs with only the HTTP method and the {@link UriInfo}, leaving the
+   * entity data to be initialized later.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   * @param httpStatusCode The HTTP response status code.
+   * @param uriInfo The {@link UriInfo} from the request.
+   */
+  public SzEntityResponse(SzHttpMethod httpMethod,
+                          int          httpStatusCode,
+                          UriInfo      uriInfo) {
+    this(httpMethod, httpStatusCode, uriInfo, null);
+  }
+
+  /**
+   * Constructs with the HTTP method, {@link UriInfo} and the
+   * {@link SzEntityData} describing the record.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   * @param httpStatusCode The HTTP response status code.
+   * @param uriInfo The {@link UriInfo} from the request.
+   * @param data The {@link SzEntityRecord} describing the record.
+   */
+  public SzEntityResponse(SzHttpMethod   httpMethod,
+                          int            httpStatusCode,
+                          UriInfo        uriInfo,
+                          SzEntityData   data)
+  {
+    super(httpMethod, httpStatusCode, uriInfo);
+    this.entityData = data;
+  }
+
 
   /**
    * Returns the data associated with this response which is an

--- a/src/main/java/com/senzing/api/model/SzErrorResponse.java
+++ b/src/main/java/com/senzing/api/model/SzErrorResponse.java
@@ -2,6 +2,7 @@ package com.senzing.api.model;
 
 import com.senzing.g2.engine.G2Fallible;
 
+import javax.ws.rs.core.UriInfo;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -120,6 +121,115 @@ public class SzErrorResponse extends SzBasicResponse {
     this(httpMethod,
          httpStatusCode,
          selfLink,
+         ((firstErrorFallible != null)
+             ? new SzError(firstErrorFallible) : null));
+  }
+
+  /**
+   * Constructs with the specified HTTP method and {@link UriInfo}.
+   *
+   * @param httpMethod The {@link SzHttpMethod} from the request.
+   *
+   * @param httpStatusCode The HTTP response code.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   */
+  public SzErrorResponse(SzHttpMethod httpMethod,
+                         int          httpStatusCode,
+                         UriInfo      uriInfo)
+  {
+    this(httpMethod, httpStatusCode, uriInfo, (SzError) null);
+  }
+
+  /**
+   * Constructs with the specified HTTP method and {@link UriInfo} and the
+   * first error.
+   *
+   * @param httpMethod The {@link SzHttpMethod} from the request.
+   *
+   * @param httpStatusCode The HTTP response code.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   *
+   * @param firstError The {@link SzError} describing the first error.
+   */
+  public SzErrorResponse(SzHttpMethod httpMethod,
+                         int          httpStatusCode,
+                         UriInfo      uriInfo,
+                         SzError      firstError)
+  {
+    super(httpMethod, httpStatusCode, uriInfo);
+    this.errors = new LinkedList<>();
+    if (firstError != null) this.errors.add(firstError);
+  }
+
+  /**
+   * Constructs with the specified HTTP method and {@link UriInfo} and the
+   * first error message.
+   *
+   * @param httpMethod The {@link SzHttpMethod} from the request.
+   *
+   * @param httpStatusCode The HTTP response code.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   *
+   * @param firstError The error message for the first error.
+   */
+  public SzErrorResponse(SzHttpMethod httpMethod,
+                         int          httpStatusCode,
+                         UriInfo      uriInfo,
+                         String       firstError)
+  {
+    this(httpMethod,
+         httpStatusCode,
+         uriInfo,
+         firstError != null ? new SzError(firstError) : null);
+  }
+
+  /**
+   * Constructs with the specified HTTP method and {@link UriInfo} and the first
+   * error.
+   *
+   * @param httpMethod The {@link SzHttpMethod} from the request.
+   *
+   * @param httpStatusCode The HTTP response code.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   *
+   * @param firstError The {@link Throwable} describing the first error.
+   */
+  public SzErrorResponse(SzHttpMethod httpMethod,
+                         int          httpStatusCode,
+                         UriInfo      uriInfo,
+                         Throwable    firstError)
+  {
+    this(httpMethod,
+         httpStatusCode,
+         uriInfo,
+         firstError != null ? new SzError(firstError) : null);
+  }
+
+  /**
+   * Constructs with the specified HTTP method and {@link UriInfo} link and
+   * the first error.
+   *
+   * @param httpMethod The {@link SzHttpMethod} from the request.
+   *
+   * @param httpStatusCode The HTTP response code.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   *
+   * @param firstErrorFallible The {@link G2Fallible} from which to extract the
+   *                           error code and exception message.
+   */
+  public SzErrorResponse(SzHttpMethod httpMethod,
+                         int          httpStatusCode,
+                         UriInfo      uriInfo,
+                         G2Fallible   firstErrorFallible)
+  {
+    this(httpMethod,
+         httpStatusCode,
+         uriInfo,
          ((firstErrorFallible != null)
              ? new SzError(firstErrorFallible) : null));
   }

--- a/src/main/java/com/senzing/api/model/SzLicenseResponse.java
+++ b/src/main/java/com/senzing/api/model/SzLicenseResponse.java
@@ -1,5 +1,7 @@
 package com.senzing.api.model;
 
+import javax.ws.rs.core.UriInfo;
+
 /**
  * A response object that contains license data.
  *
@@ -44,6 +46,38 @@ public class SzLicenseResponse extends SzResponseWithRawData {
                            SzLicenseInfo  data)
   {
     super(httpMethod, httpStatusCode, selfLink);
+    this.licenseInfo = data;
+  }
+
+  /**
+   * Constructs with only the HTTP method and the {@link UriInfo}, leaving the
+   * license info data to be initialized later.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   * @param httpStatusCode The HTTP response code.
+   * @param uriInfo The {@link UriInfo} from the request.
+   */
+  public SzLicenseResponse(SzHttpMethod httpMethod,
+                           int          httpStatusCode,
+                           UriInfo      uriInfo) {
+    this(httpMethod, httpStatusCode, uriInfo, null);
+  }
+
+  /**
+   * Constructs with the HTTP method, {@link UriInfo} and the
+   * {@link SzLicenseInfo} describing the license.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   * @param httpStatusCode The HTTP response status code.
+   * @param uriInfo The {@link UriInfo} from the request.
+   * @param data The {@link SzLicenseInfo} describing the license.
+   */
+  public SzLicenseResponse(SzHttpMethod   httpMethod,
+                           int            httpStatusCode,
+                           UriInfo        uriInfo,
+                           SzLicenseInfo  data)
+  {
+    super(httpMethod, httpStatusCode, uriInfo);
     this.licenseInfo = data;
   }
 

--- a/src/main/java/com/senzing/api/model/SzLinks.java
+++ b/src/main/java/com/senzing/api/model/SzLinks.java
@@ -1,5 +1,7 @@
 package com.senzing.api.model;
 
+import javax.ws.rs.core.UriInfo;
+
 public class SzLinks {
   private String self;
 
@@ -17,6 +19,15 @@ public class SzLinks {
    */
   public SzLinks(String self) {
     this.self = self;
+  }
+
+  /**
+   * Constructs with the specified {@link UriInfo}.
+   *
+   * @param uriInfo The {@link UriInfo} for extracting the self link.
+   */
+  public SzLinks(UriInfo uriInfo) {
+    this(uriInfo.getRequestUri().toString());
   }
 
   public String getSelf() {

--- a/src/main/java/com/senzing/api/model/SzLoadRecordResponse.java
+++ b/src/main/java/com/senzing/api/model/SzLoadRecordResponse.java
@@ -1,5 +1,6 @@
 package com.senzing.api.model;
 
+import javax.ws.rs.core.UriInfo;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -53,6 +54,41 @@ public class SzLoadRecordResponse extends SzBasicResponse
                               String       selfLink,
                               String       recordId) {
     super(httpMethod, httpStatusCode, selfLink);
+    this.recordId = recordId;
+  }
+
+  /**
+   * Constructs with only the HTTP method and the {@link UriInfo}, leaving the
+   * record ID to be initialized later.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   *
+   * @param httpStatusCode The HTTP response status code.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   */
+  public SzLoadRecordResponse(SzHttpMethod httpMethod,
+                              int          httpStatusCode,
+                              UriInfo      uriInfo) {
+    super(httpMethod, httpStatusCode, uriInfo);
+  }
+
+  /**
+   * Constructs with the HTTP method, the {@link UriInfo}, and the record ID.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   *
+   * @param httpStatusCode The HTTP response status code.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   *
+   * @param recordId The record ID of the record that was loaded.
+   */
+  public SzLoadRecordResponse(SzHttpMethod httpMethod,
+                              int          httpStatusCode,
+                              UriInfo      uriInfo,
+                              String       recordId) {
+    super(httpMethod, httpStatusCode, uriInfo);
     this.recordId = recordId;
   }
 

--- a/src/main/java/com/senzing/api/model/SzRecordResponse.java
+++ b/src/main/java/com/senzing/api/model/SzRecordResponse.java
@@ -1,5 +1,7 @@
 package com.senzing.api.model;
 
+import javax.ws.rs.core.UriInfo;
+
 /**
  * A response object that contains entity record data.
  *
@@ -39,6 +41,38 @@ public class SzRecordResponse extends SzResponseWithRawData {
                           SzEntityRecord data)
   {
     super(httpMethod, httpStatusCode, selfLink);
+    this.entityRecord = data;
+  }
+
+  /**
+   * Constructs with only the HTTP method and the {@link UriInfo}, leaving the
+   * record data to be initialized later.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   * @param httpStatusCode The HTTP response status code.
+   * @param uriInfo The {@link UriInfo} from the request.
+   */
+  public SzRecordResponse(SzHttpMethod httpMethod,
+                          int          httpStatusCode,
+                          UriInfo      uriInfo) {
+    this(httpMethod, httpStatusCode, uriInfo, null);
+  }
+
+  /**
+   * Constructs with the HTTP method, {@link UriInfo} and the {@link SzEntityRecord}
+   * describing the record.
+   *
+   * @param httpMethod The {@link SzHttpMethod}.
+   * @param httpStatusCode The HTTP response status code.
+   * @param uriInfo The {@link UriInfo} from the request.
+   * @param data The {@link SzEntityRecord} describing the record.
+   */
+  public SzRecordResponse(SzHttpMethod   httpMethod,
+                          int            httpStatusCode,
+                          UriInfo        uriInfo,
+                          SzEntityRecord data)
+  {
+    super(httpMethod, httpStatusCode, uriInfo);
     this.entityRecord = data;
   }
 

--- a/src/main/java/com/senzing/api/model/SzResponseWithRawData.java
+++ b/src/main/java/com/senzing/api/model/SzResponseWithRawData.java
@@ -7,6 +7,7 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 import javax.json.JsonValue;
+import javax.ws.rs.core.UriInfo;
 import java.io.StringReader;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -60,6 +61,43 @@ public class SzResponseWithRawData extends SzBasicResponse {
     this.rawData = JsonUtils.normalizeJsonText(rawData);
   }
 
+  /**
+   * Constructs with the specified HTTP method and {@link UriInfo}.
+   *
+   * @param httpMethod The {@link SzHttpMethod} from the request.
+   *
+   * @param httpStatusCode The HTTP response status code.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   */
+  public SzResponseWithRawData(SzHttpMethod httpMethod,
+                               int          httpStatusCode,
+                               UriInfo      uriInfo)
+  {
+    this(httpMethod, httpStatusCode, uriInfo, null);
+  }
+
+  /**
+   * Constructs with the specified HTTP method, {@link UriInfo} and
+   * object representing the raw data response from the engine.
+   *
+   * @param httpMethod The {@link SzHttpMethod} from the request.
+   *
+   * @param httpStatusCode The HTTP response status code.
+   *
+   * @param uriInfo The {@link UriInfo} from the request.
+   *
+   * @param rawData The raw data to associate with the response.
+   */
+  public SzResponseWithRawData(SzHttpMethod httpMethod,
+                               int          httpStatusCode,
+                               UriInfo      uriInfo,
+                               String       rawData)
+  {
+    super(httpMethod, httpStatusCode, uriInfo);
+
+    this.rawData = JsonUtils.normalizeJsonText(rawData);
+  }
 
   /**
    * Returns the raw data associated with this response.

--- a/src/main/java/com/senzing/api/server/LifeCycleListener.java
+++ b/src/main/java/com/senzing/api/server/LifeCycleListener.java
@@ -43,7 +43,7 @@ class LifeCycleListener implements LifeCycle.Listener {
     System.out.println("Started Senzing REST API Server on port " + port + ".");
     System.out.println();
     System.out.println("Server running at:");
-    System.out.println("http://" + this.ipAddr + ":" + port + "/");
+    System.out.println("http://" + this.ipAddr.getHostAddress() + ":" + port + "/");
     System.out.println();
     if (this.fileMonitor != null) {
       this.fileMonitor.signalReady();

--- a/src/main/java/com/senzing/api/server/SzApiServer.java
+++ b/src/main/java/com/senzing/api/server/SzApiServer.java
@@ -373,21 +373,6 @@ public class SzApiServer {
   }
 
   /**
-   * Uses the {@linkplain #getBaseUrl() base URL} to build a link with the
-   * specified path.
-   *
-   * @param path The path to use for building the path.
-   * @return The URL link for the path with the base URL.
-   */
-  public String makeLink(String path) {
-    this.assertNotShutdown();
-    String sep = "";
-    if (path.startsWith("/")) path = path.substring(1);
-    if (!this.baseUrl.endsWith("/")) sep = "/";
-    return this.baseUrl + sep + path;
-  }
-
-  /**
    * Utility method to ensure a command line argument with the specified index
    * exists and if not then throws an exception.
    *
@@ -930,7 +915,7 @@ public class SzApiServer {
       this.allowedOrigins = (String) options.get(Option.ALLOWED_ORIGINS);
     }
 
-    this.baseUrl = "http://" + ipAddr + ":" + httpPort + "/";
+    this.baseUrl = "http://" + ipAddr.getHostAddress() + ":" + httpPort + "/";
     this.g2Product = new G2ProductJNI();
     int initResult = this.g2Product.init(moduleName, ini, verbose);
     if (initResult < 0) {

--- a/src/main/java/com/senzing/api/server/services/AdminServices.java
+++ b/src/main/java/com/senzing/api/server/services/AdminServices.java
@@ -4,6 +4,8 @@ import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
 
 import com.senzing.api.model.*;
 import com.senzing.api.server.SzApiServer;
@@ -25,10 +27,8 @@ public class AdminServices {
    */
   @GET
   @Path("heartbeat")
-  public SzBasicResponse heartbeat() {
-    SzApiServer server = SzApiServer.getInstance();
-    String selfLink = server.makeLink("/heartbeat");
-    return new SzBasicResponse(GET, 200, selfLink);
+  public SzBasicResponse heartbeat(@Context UriInfo uriInfo) {
+    return new SzBasicResponse(GET, 200, uriInfo);
   }
 
   /**
@@ -37,17 +37,13 @@ public class AdminServices {
   @GET
   @Path("license")
   public SzLicenseResponse license(
-      @DefaultValue("false") @QueryParam("withRaw") boolean withRaw)
+      @DefaultValue("false") @QueryParam("withRaw") boolean withRaw,
+      @Context                                      UriInfo uriInfo)
     throws WebApplicationException
   {
     SzApiServer server = SzApiServer.getInstance();
 
     return server.executeInThread(() -> {
-      String selfLink = server.makeLink("/license");
-      if (withRaw) {
-        selfLink += "?withRaw=true";
-      }
-
       try {
         G2Product productApi = server.getProductApi();
 
@@ -59,7 +55,7 @@ public class AdminServices {
         SzLicenseInfo info = SzLicenseInfo.parseLicenseInfo(null, jsonObject);
 
         SzLicenseResponse response
-            = new SzLicenseResponse(GET, 200, selfLink);
+            = new SzLicenseResponse(GET, 200, uriInfo);
         response.setLicense(info);
         if (withRaw) response.setRawData(rawData);
         return response;
@@ -68,7 +64,7 @@ public class AdminServices {
         throw e;
 
       } catch (Exception e) {
-        throw newInternalServerErrorException(GET, selfLink, e);
+        throw newInternalServerErrorException(GET, uriInfo, e);
       }
     });
   }

--- a/src/main/java/com/senzing/api/server/services/ServicesUtil.java
+++ b/src/main/java/com/senzing/api/server/services/ServicesUtil.java
@@ -10,6 +10,7 @@ import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -22,13 +23,12 @@ import java.util.List;
 public class ServicesUtil {
   /**
    * Creates an {@link InternalServerErrorException} and builds a response
-   * with an {@link SzErrorResponse} using the specified self link
+   * with an {@link SzErrorResponse} using the specified {@link UriInfo}
    * and the specified exception.
    *
    * @param httpMethod The HTTP method for the request.
    *
-   * @param selfLink The link to the service to use in building the
-   *                 {@link SzErrorResponse}.
+   * @param uriInfo The {@link UriInfo} from the request.
    *
    * @param exception The exception that caused the error.
    *
@@ -36,24 +36,23 @@ public class ServicesUtil {
    */
   static InternalServerErrorException newInternalServerErrorException(
       SzHttpMethod  httpMethod,
-      String        selfLink,
+      UriInfo       uriInfo,
       Exception     exception)
   {
     Response.ResponseBuilder builder = Response.status(500);
     builder.entity(
-        new SzErrorResponse(httpMethod, 500, selfLink, exception));
+        new SzErrorResponse(httpMethod, 500, uriInfo, exception));
     return new InternalServerErrorException(builder.build());
   }
 
   /**
    * Creates an {@link InternalServerErrorException} and builds a response
-   * with an {@link SzErrorResponse} using the specified self link
+   * with an {@link SzErrorResponse} using the specified  {@link UriInfo}
    * and the specified {@link G2Fallible} to get the last exception from.
    *
    * @param httpMethod The HTTP method for the request.
    *
-   * @param selfLink The link to the service to use in building the
-   *                 {@link SzErrorResponse}.
+   * @param uriInfo The {@link UriInfo} from the request.
    *
    * @param fallible The {@link G2Fallible} to get the last exception from.
    *
@@ -61,25 +60,24 @@ public class ServicesUtil {
    */
   static InternalServerErrorException newInternalServerErrorException(
       SzHttpMethod  httpMethod,
-      String        selfLink,
+      UriInfo       uriInfo,
       G2Fallible    fallible)
   {
     Response.ResponseBuilder builder = Response.status(500);
     builder.entity(
-        new SzErrorResponse(httpMethod, 500, selfLink, fallible));
+        new SzErrorResponse(httpMethod, 500, uriInfo, fallible));
     fallible.clearLastException();
     return new InternalServerErrorException(builder.build());
   }
 
   /**
    * Creates an {@link NotFoundException} and builds a response
-   * with an {@link SzErrorResponse} using the specified self link
+   * with an {@link SzErrorResponse} using the specified {@link UriInfo}
    * and the specified {@link G2Fallible} to get the last exception from.
    *
    * @param httpMethod The HTTP method for the request.
    *
-   * @param selfLink The link to the service to use in building the
-   *                 {@link SzErrorResponse}.
+   * @param uriInfo The {@link UriInfo} from the request.
    *
    * @param fallible The {@link G2Fallible} to get the last exception from.
    *
@@ -87,45 +85,43 @@ public class ServicesUtil {
    */
   static NotFoundException newNotFoundException(
       SzHttpMethod  httpMethod,
-      String        selfLink,
+      UriInfo       uriInfo,
       G2Fallible    fallible)
   {
     Response.ResponseBuilder builder = Response.status(404);
     builder.entity(
-        new SzErrorResponse(httpMethod, 404, selfLink, fallible));
+        new SzErrorResponse(httpMethod, 404, uriInfo, fallible));
     fallible.clearLastException();
     return new NotFoundException(builder.build());
   }
 
   /**
    * Creates an {@link NotFoundException} and builds a response
-   * with an {@link SzErrorResponse} using the specified self link.
+   * with an {@link SzErrorResponse} using the specified {@link UriInfo}.
    *
    * @param httpMethod The HTTP method for the request.
    *
-   * @param selfLink The link to the service to use in building the
-   *                 {@link SzErrorResponse}.
+   * @param uriInfo The {@link UriInfo} from the request.
    *
    * @return The {@link InternalServerErrorException}
    */
   static NotFoundException newNotFoundException(
       SzHttpMethod  httpMethod,
-      String        selfLink)
+      UriInfo       uriInfo)
   {
     Response.ResponseBuilder builder = Response.status(404);
     builder.entity(
-        new SzErrorResponse(httpMethod, 404, selfLink));
+        new SzErrorResponse(httpMethod, 404, uriInfo));
     return new NotFoundException(builder.build());
   }
 
   /**
    * Creates an {@link NotFoundException} and builds a response
-   * with an {@link SzErrorResponse} using the specified self link.
+   * with an {@link SzErrorResponse} using the specified {@link UriInfo}.
    *
    * @param httpMethod The HTTP method for the request.
    *
-   * @param selfLink The link to the service to use in building the
-   *                 {@link SzErrorResponse}.
+   * @param uriInfo The {@link UriInfo} from the request.
    *
    * @param errorMessage The error message.
    *
@@ -133,39 +129,38 @@ public class ServicesUtil {
    */
   static NotFoundException newNotFoundException(
       SzHttpMethod  httpMethod,
-      String        selfLink,
+      UriInfo       uriInfo,
       String        errorMessage)
   {
     Response.ResponseBuilder builder = Response.status(404);
     builder.entity(
         new SzErrorResponse(
-            httpMethod, 404, selfLink, errorMessage));
+            httpMethod, 404, uriInfo, errorMessage));
     return new NotFoundException(builder.build());
   }
 
   /**
    * Creates an {@link BadRequestException} and builds a response
-   * with an {@link SzErrorResponse} using the specified self link.
+   * with an {@link SzErrorResponse} using the specified {@link UriInfo}.
    *
    * @param httpMethod The HTTP method for the request.
    *
-   * @param selfLink The link to the service to use in building the
-   *                 {@link SzErrorResponse}.
+   * @param uriInfo The {@link UriInfo} from the request.
    *
    * @param errorMessage The error message.
    *
    * @return The {@link BadRequestException} that was created with the
-   *         specified http method and self link.
+   *         specified http method and {@link UriInfo}.
    */
   static BadRequestException newBadRequestException(
       SzHttpMethod  httpMethod,
-      String        selfLink,
+      UriInfo       uriInfo,
       String        errorMessage)
   {
     Response.ResponseBuilder builder = Response.status(400);
     builder.entity(
         new SzErrorResponse(
-            httpMethod, 400, selfLink, errorMessage));
+            httpMethod, 400, uriInfo, errorMessage));
     return new BadRequestException(builder.build());
   }
 
@@ -372,7 +367,7 @@ public class ServicesUtil {
    *
    * @param httpMethod The HTTP method.
    *
-   * @param selfLink The link to the API service endpoint.
+   * @param uriInfo The {@link UriInfo} from the request.
    *
    * @return The {@link List} of {@link SzEntityIdentifier} instances that was
    *         parsed from the specified parameters.
@@ -381,7 +376,7 @@ public class ServicesUtil {
       List<String>  params,
       String        paramName,
       SzHttpMethod  httpMethod,
-      String        selfLink)
+      UriInfo       uriInfo)
   {
     List<SzEntityIdentifier> result = new ArrayList<>(params.size());
 
@@ -392,7 +387,7 @@ public class ServicesUtil {
 
       } catch (Exception e) {
         throw newBadRequestException(
-            httpMethod, selfLink,
+            httpMethod, uriInfo,
             "Improperly formatted entity identifier parameter: "
             + paramName + "=" + param);
       }


### PR DESCRIPTION
- Modified "model" classes to accept "UriInfo" objects in addition to "String" self links.  The UriInfo object is used to extract the self link from the associated request.

- Modified the "services" classes to inject the "UriInfo" using the "@Context" annotation so the actual request URL can be used in the self link rather than the constructed ones.

- Removed unused methods from SzApiServer (makeLink())

- Fixed LifeCycleListener to output the host address instead of the InetAddr object